### PR TITLE
Legg til innledning, oppsett-overskrift og kontaktseksjon i howto

### DIFF
--- a/howto.md
+++ b/howto.md
@@ -1,7 +1,14 @@
 # Komme i gang med varsler
 
+Varsler lar teamet ditt nå brukeren med beskjeder, oppgaver og innboksvarsler
+på Min side. Du sender dem som Kafka-eventer på ett felles topic – Min side tar
+seg av visningen i varselbjella og på varselsiden, og eventuell ekstern
+varsling på sms eller epost.
+
 > [!TIP]
 > For brukeropplevelsen er det viktig at du bruker riktig type varsel. Ta gjerne en ekstrasjekk med [innholdsguiden vår](https://navikt.github.io/tms-dokumentasjon/guide/).
+
+## Oppsett
 
 1. Kafka tilgang: Opprett en pull-request mot topic `aapen-brukervarsel-v1`
    i [min-side-brukervarsel-topic-iac](https://github.com/navikt/min-side-brukervarsel-topic-iac).
@@ -383,3 +390,7 @@ Eksempler:
   "appnavn": "demo-app"
 }
 ```
+
+## Kontakt
+
+Ta kontakt med oss [på Slack](https://nav-it.slack.com/archives/C0912F59V29) hvis du lurer på noe.


### PR DESCRIPTION
`howto.md` rendres både på [tms-docs](https://tms-docs.nav.no/varsler/start/) og på tms-dokumentasjon. Guidene der skrives i hvert sitt repo av forskjellige folk, og det synes på sidene: de åpner og avsluttes ulikt. Dette er én av fire små PR-er som gir dem samme form.

Dette dokumentet hadde mest å hente:

- **Innledning først.** Siden åpnet med en tips-boks før leseren fikk vite hva varsler er. Nå kommer avsnittet som forklarer hva varsler er først, og tipset står som det det er – en kommentar ved siden av.
- **Egen overskrift for stegene.** De tre første punktene lå løst under h1-en, uten overskrift og uten plass i innholdsfortegnelsen. De ligger nå under `## Oppsett`.
- **Kontaktseksjon** på slutten, lik den de andre guidene får.

Ingen endringer i det tekniske innholdet, og ingen eksisterende ankre endrer seg – `## Oppsett` legger bare til ett nytt.

`howto.md` ligger i `paths-ignore` for både `on-push-to-main` og `on-push-to-other-branches`, så dette trigger ingen bygg eller deploy. Merge trigger `update_docs`, som bygger tms-dokumentasjon på nytt.

Merk: navikt/tms-docs#36 viser stegene under `## Oppsett` som en nummerert steg-liste, slik de lokale sidene der gjør. Den PR-en venter på denne, siden den peker på overskriften herfra.
